### PR TITLE
ci: hybrid releases, auto-versioned naming

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,15 +1,20 @@
 name: Build & Release Firmware
 
 # Builds the SillyGoose PlatformIO environments and publishes their .uf2
-# files to a rolling, per-branch GitHub Release on every push.
+# files to GitHub Releases on every push. Per push, two releases are updated:
 #
-# - main                -> stable release, tag "latest"
-# - not-flight-tested   -> prerelease, tag "not-flight-tested-latest"
+#   1. A permanent, versioned history release   (tag <branch>-v<X>)
+#   2. A rolling "latest" release whose assets keep stable filenames, so the
+#      download links never change.
 #
-# The PlatformIO project lives in a subfolder; the git repo root is one level
-# up. On not-flight-tested the vendored libs are submodules, on main they are
-# committed directly, so `submodules: recursive` is correct on both branches
-# (it simply no-ops where there is nothing to fetch).
+#     main              -> "Flight Firmware vX",            rolling tag: latest
+#     not-flight-tested -> "Not-Flight-Tested Firmware vX", rolling tag: not-flight-tested-latest
+#
+# X auto-bumps: it is the per-branch commit count (git rev-list --count HEAD).
+#
+# Layout notes: the git repo root is one level up from the PlatformIO project.
+# On not-flight-tested the vendored libs are submodules; on main they are
+# committed directly, so `submodules: recursive` is correct on both branches.
 
 on:
   push:
@@ -17,14 +22,12 @@ on:
       - main
       - not-flight-tested
   # Validate the build on every PR into a protected branch before it merges.
-  # The release job below is guarded to push events only, so PR runs build &
-  # validate but never publish.
+  # The release job is guarded to push events only, so PRs build but never publish.
   pull_request:
     branches:
       - main
       - not-flight-tested
 
-# Allow the built-in GITHUB_TOKEN to create/update releases and tags.
 permissions:
   contents: write
 
@@ -71,89 +74,134 @@ jobs:
         working-directory: ${{ env.PIO_PROJECT_DIR }}
         run: pio run -e ${{ matrix.environment }}
 
-      - name: Collect & rename UF2
+      - name: Collect UF2
         working-directory: ${{ env.PIO_PROJECT_DIR }}
         run: |
           set -euo pipefail
           # Both branches' post_uf2.py emit the canonical firmware.uf2 in the
-          # build dir, regardless of how each names its project-root copy
-          # (latest_firmware.uf2 vs <env>_<timestamp>.uf2). Use the build dir
-          # so this step is branch-independent.
+          # build dir, regardless of how each names its project-root copy. Use
+          # the build dir so this step is branch-independent; all asset naming
+          # (version + branch suffix) happens later in the release job.
           uf2=".pio/build/${{ matrix.environment }}/firmware.uf2"
           if [ ! -f "$uf2" ]; then
             echo "::error::No .uf2 at $uf2 for ${{ matrix.environment }}"
             find .pio/build -name '*.uf2' 2>/dev/null | sed 's/^/  found: /' || true
             exit 1
           fi
-          # Build a versioned asset name so a downloaded .uf2 is traceable to
-          # its exact build: <env>[-v<firmwareVersion>]-<date>-g<shortSHA>.uf2
-          short_sha="$(echo "${{ github.sha }}" | cut -c1-7)"
-          date_stamp="$(date -u +%Y%m%d)"
-          # firmwareVersion lives in platformio.ini as ...='"1.00"'; best-effort.
-          fw="$(grep -oE "firmwareVersion[^\"]*\"[0-9]+\.[0-9]+\"" platformio.ini | grep -oE '[0-9]+\.[0-9]+' | head -n1 || true)"
-          if [ -n "$fw" ]; then ver="-v${fw}"; else ver=""; fi
-          asset="${{ matrix.environment }}${ver}-${date_stamp}-g${short_sha}.uf2"
           mkdir -p "$GITHUB_WORKSPACE/dist"
-          cp "$uf2" "$GITHUB_WORKSPACE/dist/${asset}"
-          echo "Packaged $uf2 -> dist/${asset}"
+          cp "$uf2" "$GITHUB_WORKSPACE/dist/${{ matrix.environment }}.uf2"
+          echo "Collected $uf2 -> dist/${{ matrix.environment }}.uf2"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: uf2-${{ matrix.environment }}
-          # Each runner builds exactly one env, so dist/ holds a single .uf2.
-          path: dist/*.uf2
+          path: dist/${{ matrix.environment }}.uf2
           if-no-files-found: error
 
   release:
     name: Publish release
     needs: build
     runs-on: ubuntu-latest
-    # Never publish from a pull_request event — only on real pushes to the
-    # protected branches.
+    # Never publish from a pull_request event — only on real pushes.
     if: github.event_name == 'push'
     steps:
+      - name: Checkout (full history for version count)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download all UF2 artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: uf2-*
-          path: dist
+          path: incoming
           merge-multiple: true
 
       - name: Determine release metadata
         id: meta
         run: |
           set -euo pipefail
-          short_sha="$(echo "${{ github.sha }}" | cut -c1-7)"
-          date_stamp="$(date -u +%Y%m%d)"
-          # Unique tag per build so every push is preserved as its own release:
-          #   <branch>-<date>-g<shortSHA>  e.g. main-20260607-g374ab3a
-          echo "tag=${{ github.ref_name }}-${date_stamp}-g${short_sha}" >> "$GITHUB_OUTPUT"
+          # Auto-bumping version: per-branch commit count.
+          x="$(git rev-list --count HEAD)"
+          echo "x=${x}" >> "$GITHUB_OUTPUT"
           if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "name=Flight firmware ${date_stamp} (${short_sha})" >> "$GITHUB_OUTPUT"
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "history_tag=main-v${x}"            >> "$GITHUB_OUTPUT"
+            echo "name=Flight Firmware v${x}"         >> "$GITHUB_OUTPUT"
+            echo "latest_tag=latest"                  >> "$GITHUB_OUTPUT"
+            echo "prerelease=false"                   >> "$GITHUB_OUTPUT"
+            echo "make_latest=true"                   >> "$GITHUB_OUTPUT"
+            echo "suffix="                            >> "$GITHUB_OUTPUT"
           else
-            echo "name=Not-flight-tested ${date_stamp} (${short_sha})" >> "$GITHUB_OUTPUT"
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "history_tag=not-flight-tested-v${x}"          >> "$GITHUB_OUTPUT"
+            echo "name=Not-Flight-Tested Firmware v${x}"        >> "$GITHUB_OUTPUT"
+            echo "latest_tag=not-flight-tested-latest"          >> "$GITHUB_OUTPUT"
+            echo "prerelease=true"                              >> "$GITHUB_OUTPUT"
+            echo "make_latest=false"                            >> "$GITHUB_OUTPUT"
+            echo "suffix=_not_flight_tested"                    >> "$GITHUB_OUTPUT"
           fi
 
-      - name: List artifacts
-        run: ls -la dist
+      - name: Stage named assets
+        run: |
+          set -euo pipefail
+          x="${{ steps.meta.outputs.x }}"
+          suffix="${{ steps.meta.outputs.suffix }}"
+          mkdir -p history latest
+          for f in incoming/*.uf2; do
+            env_name="$(basename "$f" .uf2)"
+            # Versioned name for the permanent history release.
+            cp "$f" "history/${env_name}${suffix}_v${x}.uf2"
+            # Stable name for the rolling "latest" release (permanent links).
+            cp "$f" "latest/${env_name}${suffix}.uf2"
+          done
+          echo "--- history ---"; ls -1 history
+          echo "--- latest  ---"; ls -1 latest
 
-      - name: Publish release
+      - name: Publish versioned history release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
+          tag_name: ${{ steps.meta.outputs.history_tag }}
           name: ${{ steps.meta.outputs.name }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
+          make_latest: false
           target_commitish: ${{ github.sha }}
           body: |
-            Automated build from `${{ github.ref_name }}` @ `${{ github.sha }}`.
+            Automated build of `${{ github.ref_name }}` @ `${{ github.sha }}` (v${{ steps.meta.outputs.x }}).
 
             Environments: SillyGooseV1, SillyGooseV2, SillyGooseV1Sim, SillyGooseV2Sim.
 
-            Each push publishes a new, permanent release tagged
-            `${{ github.ref_name }}-<date>-g<shortSHA>`, so build history is kept.
-            For `main` the newest non-prerelease is automatically marked *Latest*.
-          files: dist/*.uf2
+            Permanent, versioned build. The always-current build lives at the
+            `${{ steps.meta.outputs.latest_tag }}` release.
+          files: history/*.uf2
+          fail_on_unmatched_files: true
+
+      - name: Clear stale assets from the rolling "latest" release
+        # Stable filenames overwrite cleanly, but this also removes any assets
+        # left over from a previous naming scheme so "latest" stays tidy.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.meta.outputs.latest_tag }}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
+              --json assets -q '.assets[].name' | while read -r a; do
+                [ -n "$a" ] && gh release delete-asset "$tag" "$a" \
+                  --repo "$GITHUB_REPOSITORY" --yes || true
+              done
+          fi
+
+      - name: Update rolling "latest" release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.latest_tag }}
+          name: ${{ steps.meta.outputs.name }} (latest)
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          make_latest: ${{ steps.meta.outputs.make_latest }}
+          target_commitish: ${{ github.sha }}
+          body: |
+            Always points at the newest `${{ github.ref_name }}` build
+            (currently v${{ steps.meta.outputs.x }}, `${{ github.sha }}`).
+            Filenames here are stable, so these download links never change.
+          files: latest/*.uf2
           fail_on_unmatched_files: true


### PR DESCRIPTION
Each push now publishes two releases per branch:
- a permanent, versioned history release (tag <branch>-v<X>) with assets named <env>[_not_flight_tested]_v<X>.uf2
- a rolling "latest" release (tag latest / not-flight-tested-latest) carrying the same builds under STABLE filenames (<env>[_not_flight_tested].uf2) so the download links never change.

X auto-bumps as the per-branch commit count (git rev-list --count HEAD), so the release job now checks out full history (fetch-depth: 0). Release titles are "Flight Firmware vX" / "Not-Flight-Tested Firmware vX". main's rolling release is marked make_latest so it keeps GitHub's "Latest" badge; history releases never claim it. All asset naming moved out of the build job.